### PR TITLE
Fix singular objectives and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-local-guides-api",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "(Unofficial) Get your google contribution metadata using this api!",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Jin",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.19.2"
+    "axios": "^0.22.0"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
-    "mocha": "^7.1.2"
+    "mocha": "^9.1.2"
   },
   "keywords": [
     "google contributions",

--- a/src/ContributionMetadata.js
+++ b/src/ContributionMetadata.js
@@ -31,7 +31,7 @@ class ContributionMetadata {
      * @return {string} # of reviews
      */
     getReviews() {
-        let pattern = /(\d+) reviews/g;
+        let pattern = /(\d+) review[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -41,7 +41,7 @@ class ContributionMetadata {
      * @return {string} # of ratings
      */
     getRatings() {
-        let pattern = /(\d+) ratings/g;
+        let pattern = /(\d+) rating[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -51,7 +51,7 @@ class ContributionMetadata {
      * @return {string} # of questions
      */
     getQuestions() {
-        let pattern = /(\d+) answers/g;
+        let pattern = /(\d+) answer[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -61,7 +61,7 @@ class ContributionMetadata {
      * @return {string} # of places added
      */
     getPlacesAdded() {
-        let pattern = /(\d+) places added/g;
+        let pattern = /(\d+) place[s]? added/g;
         return this.getMatch(pattern);
     }
 
@@ -71,7 +71,7 @@ class ContributionMetadata {
      * @return {string} # of edits
      */
     getEdits() {
-        let pattern = /(\d+) edits/g;
+        let pattern = /(\d+) edit[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -81,7 +81,7 @@ class ContributionMetadata {
      * @return {string} # of facts
      */
     getFacts() {
-        let pattern = /(\d+) facts/g;
+        let pattern = /(\d+) fact[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -91,7 +91,7 @@ class ContributionMetadata {
      * @return {string} # of videos
      */
     getVideos() {
-        let pattern = /(\d+) videos/g;
+        let pattern = /(\d+) video[s]?/g;
         return this.getMatch(pattern);
     }
 
@@ -111,7 +111,7 @@ class ContributionMetadata {
      * @return {string} # of roads
      */
     getRoadsAdded() {
-        let pattern = /(\d+) roads added/g;
+        let pattern = /(\d+) road[s]? added/g;
         return this.getMatch(pattern);
     }
 
@@ -121,7 +121,7 @@ class ContributionMetadata {
      * @return {string} # of published lists
      */
     getPublishedLists() {
-        let pattern = /(\d+) published lists/g;
+        let pattern = /(\d+) published list[s]?/g;
         return this.getMatch(pattern);
     }
 

--- a/src/ContributionMetadata.js
+++ b/src/ContributionMetadata.js
@@ -130,7 +130,7 @@ class ContributionMetadata {
      * @public
      * @return {JSON} metadata
      */
-    async getMetadata() {
+    getMetadata() {
         return {
             points: this.getPoints(),
             level: this.getLevel(),
@@ -156,6 +156,7 @@ class ContributionMetadata {
      */
     getMatch(pattern) {
         let matches = pattern.exec(this.responseBody);
+        if (!matches) return null;
         return matches.length > 0 ? matches[1] : "";
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ describe('ContributionMetadata Class', () => {
 
             await contributionMetadata.init(process.env.CONTRIB_LINK);
             metadata = contributionMetadata.getMetadata();
+            console.log(metadata);
         });
 
         for (const reqAttr of ["points", 'level', 'reviews', 'ratings', 'questions', 'placesAdded', 'edits', 'facts', 'videos', 'qa', 'roadsAdded', 'listsPublished']) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,44 +1,29 @@
 const expect = require('chai').expect;
 
-require('dotenv').config({path: "./.env"});
+require('dotenv').config({ path: "./.env" });
 const ContributionMetadata = require('../src/ContributionMetadata');
 
-describe('ContributionMetadata Class',  () => {
+describe('ContributionMetadata Class', () => {
     let contributionMetadata;
 
     describe('getMetadata()', () => {
         let metadata;
 
-        beforeEach(async () => {
+        before(async () => {
             contributionMetadata = new ContributionMetadata();
+
             await contributionMetadata.init(process.env.CONTRIB_LINK);
             metadata = contributionMetadata.getMetadata();
         });
 
-        it('should have each attribute be a string', async () => {
-            for (let attr in metadata) {
-                if (metadata.hasOwnProperty(attr)) {
-                    expect(metadata[attr]).to.be.a('string');
-                }
-            }
-        });
-
-        it('each attribute should be able to parse into an Int', async () => {
-            for (let attr in metadata) {
-                if (metadata.hasOwnProperty(attr)) {
-                    let parseIntAttr = parseInt(metadata[attr]);
-                    expect(parseIntAttr).to.be.a('number');
-                }
-            }
-        });
-
-        it('parsedInt attribute should equal to or greater than zero', async () => {
-            for (let attr in metadata) {
-                if (metadata.hasOwnProperty(attr)) {
-                    let parseIntAttr = parseInt(metadata[attr]);
-                    expect(parseIntAttr >= 0).to.equal(true);
-                }
-            }
-        });
+        for (const reqAttr of ["points", 'level', 'reviews', 'ratings', 'questions', 'placesAdded', 'edits', 'facts', 'videos', 'qa', 'roadsAdded', 'listsPublished']) {
+            it('metadata should have attribute ' + reqAttr, async () => {
+                expect(metadata[reqAttr]).to.not.be.null;
+                expect(metadata[reqAttr]).to.be.a('string');
+                let parseIntAttr = parseInt(metadata[reqAttr]);
+                expect(parseIntAttr).to.be.a('number');
+                expect(parseIntAttr >= 0).to.equal(true);
+            })
+        }
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,6 @@ describe('ContributionMetadata Class', () => {
 
             await contributionMetadata.init(process.env.CONTRIB_LINK);
             metadata = contributionMetadata.getMetadata();
-            console.log(metadata);
         });
 
         for (const reqAttr of ["points", 'level', 'reviews', 'ratings', 'questions', 'placesAdded', 'edits', 'facts', 'videos', 'qa', 'roadsAdded', 'listsPublished']) {


### PR DESCRIPTION
Hi @JinKim7,

I originally tried to fix what I mentioned in https://github.com/JinKim7/google-local-guides-api/issues/4#issuecomment-939193637, but did change some other things too:

https://github.com/JinKim7/google-local-guides-api/commit/4437b83270267073cb21976384b1903ce2b7be2c: I updated the dependencies as there were some severe security vulnerabilities.

https://github.com/JinKim7/google-local-guides-api/commit/508acf9684b11ba848cecddbaedc639dd09bfd51: The written tests did not seem to work, partly because they were only checking if the attributes of the object were strings and could be converted to numbers, but not if the object actually contains the attributes it is supposed to. As far as I understand, [the `getMetdata()` method of `ContributionMetadata.js`](https://github.com/JinKim7/google-local-guides-api/blob/e19c8707b2ee5f4b1a6a0a5f3305731df8c17708/src/ContributionMetadata.js) returned a promise that the test did not wait for. So the tests were executed for the attributes of the promise. I fixed that by making `getMetadata()` synchronous and rewriting the tests to check for every single attribute.

https://github.com/JinKim7/google-local-guides-api/commit/04313458578f804d860fb7e9076a6ce56e5131b8: I fixed the original issue of not being able to parse the objective when there is only 1 published list. I noticed same behaviour for ratings and assumed that the other objectives would be affected as well. So I changed the matching patterns for all of them, even while this fix is currently only confirmed to be working for published lists and ratings.

https://github.com/JinKim7/google-local-guides-api/pull/6/commits/96043f2d3f6f33480fba0bef010d7cfccdf353fd: I updated the version to 1.0.7. Latest version here on GitHub was 1.0.5, but latest version on npm was 1.0.6.

Let me know what you think :)