### PR TITLE
updated categories, added number parsing, and fixed minor regex bug to handle singular + plural cases 

### DIFF
--- a/src/ContributionMetadata.js
+++ b/src/ContributionMetadata.js
@@ -1,173 +1,243 @@
-const axios = require('axios');
+const axios = require("axios");
+
+/**
+ * removed the published lists as those no longer count
+ * added some new contribution categories
+ * renamed "questions" to "answers"
+ * parse number helper function added
+ * add star after each of s- so regardless if singular (for 1) or plural - it will handle
+ * ^we found this out by console.log the responseBody and test it on regex101.com 
+ * updated regex to handle commas as noticed first digit cutting off when comma present
+ */
+
+// note too: regex is limited to english version of google maps as it uses english words to match
 
 class ContributionMetadata {
-    async init(link) {
-        this.responseBody = await this.getResponseBody(link);
-    }
+  async init(link) {
+    this.responseBody = await this.getResponseBody(link);
+  }
 
-    /**
-     * Gets how many points is associated with your Local Guide Profile
-     * @public
-     * @return {string} # of points
-     */
-    getPoints() {
-        let pattern = /((\d|,)+) Points/g;
-        return this.getMatch(pattern);
-    }
+  // helper method for parsing numbers from strings
+  static parseNumber(str) {
+    const intAmount = str.replace(/,/g, ""); // remove commas
+    return parseInt(intAmount, 10); // parse as an integer
+  }
 
-    /**
-     * Gets what level you are on your Local Guide Profile
-     * @public
-     * @return {string} your level
-     */
-    getLevel() {
-        let pattern = /Level (\d+) Local Guide/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * gets how many points is associated with your Local Guide Profile
+   * @public
+   * @return {number} # of points
+   */
+  getPoints() {
+    let pattern = /((\d|,)+) Points/g;
+    const pointsString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(pointsString);
+  }
 
-    /**
-     * Gets how many reviews you have left associated with your Local Guide Profile
-     * @public
-     * @return {string} # of reviews
-     */
-    getReviews() {
-        let pattern = /(\d+) reviews/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets what level you are on your Local Guide Profile.
+   * @public
+   * @return {number} - Your level.
+   */
+  getLevel() {
+    let pattern = /Level (\d+) Local Guide/g;
+    const levelString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(levelString);
+  }
 
-    /**
-     * Gets how many ratings you gave associated with your Local Guide Profile
-     * @public
-     * @return {string} # of ratings
-     */
-    getRatings() {
-        let pattern = /(\d+) ratings/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many reviews you have associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of reviews.
+   */
+  getReviews() {
+    let pattern = /(\d+(?:,\d+)*) reviews/g;
+    const reviewsString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(reviewsString);
+  }
 
-    /**
-     * Gets how many questions you left associated with your Local Guide Profile
-     * @public
-     * @return {string} # of questions
-     */
-    getQuestions() {
-        let pattern = /(\d+) answers/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many ratings you gave associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of ratings.
+   */
+  getRatings() {
+    let pattern = /(\d+(?:,\d+)*) ratings*/g;
+    const ratingsString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(ratingsString);
+  }
 
-    /**
-     * Gets how many places you added associated with your Local Guide Profile
-     * @public
-     * @return {string} # of places added
-     */
-    getPlacesAdded() {
-        let pattern = /(\d+) places added/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many photos you uploaded associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of photos.
+   */
+  getPhotos() {
+    let pattern = /(\d+(?:,\d+)*) photos*/g;
+    const photosString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(photosString);
+  }
 
-    /**
-     * Gets how many edits you made associated with your Local Guide Profile
-     * @public
-     * @return {string} # of edits
-     */
-    getEdits() {
-        let pattern = /(\d+) edits/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many videos you uploaded associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of videos.
+   */
+  getVideos() {
+    let pattern = /(\d+(?:,\d+)*) videos*/g;
+    const videosString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(videosString);
+  }
 
-    /**
-     * Gets how many facts you left associated with your Local Guide Profile
-     * @public
-     * @return {string} # of facts
-     */
-    getFacts() {
-        let pattern = /(\d+) facts/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many captions you added associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of captions.
+   */
+  getCaptions() {
+    let pattern = /(\d+(?:,\d+)*) captions*/g;
+    const captionsString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(captionsString);
+  }
 
-    /**
-     * Gets how many videos you uploaded associated with your Local Guide Profile
-     * @public
-     * @return {string} # of videos
-     */
-    getVideos() {
-        let pattern = /(\d+) videos/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many answers you provided associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of answers.
+   */
+  getAnswers() {
+    let pattern = /(\d+(?:,\d+)*) answers*/g;
+    const answersString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(answersString);
+  }
 
-    /**
-     * Gets how many Q&As you answered associated with your Local Guide Profile
-     * @public
-     * @return {string} # of Q&As
-     */
-    getQA() {
-        let pattern = /(\d+) Q\\\\u0026A/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many edits you made associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of edits.
+   */
+  getEdits() {
+    let pattern = /(\d+(?:,\d+)*) edits*/g;
+    const editsString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(editsString);
+  }
 
-    /**
-     * Gets how many roads you added associated with your Local Guide Profile
-     * @public
-     * @return {string} # of roads
-     */
-    getRoadsAdded() {
-        let pattern = /(\d+) roads added/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many reports of incorrect info you made associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of reports of incorrect info.
+   */
+  getReportedIncorrect() {
+    let pattern = /(\d+(?:,\d+)*) reported incorrect/g;
+    const reportedIncorrectString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(reportedIncorrectString);
+  }
 
-    /**
-     * Gets how many lists you published associated with your Local Guide Profile
-     * @public
-     * @return {string} # of published lists
-     */
-    getPublishedLists() {
-        let pattern = /(\d+) published lists/g;
-        return this.getMatch(pattern);
-    }
+  /**
+   * Gets how many facts you checked associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of facts checked.
+   */
+  getFactsChecked() {
+    let pattern = /(\d+(?:,\d+)*) facts* checked/g;
+    const factsCheckedString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(factsCheckedString);
+  }
 
-    /**
-     * Gets all the metadata in one object
-     * @public
-     * @return {JSON} metadata
-     */
-    async getMetadata() {
-        return {
-            points: this.getPoints(),
-            level: this.getLevel(),
-            reviews: this.getReviews(),
-            ratings: this.getRatings(),
-            questions: this.getQuestions(),
-            placesAdded: this.getPlacesAdded(),
-            edits: this.getEdits(),
-            facts: this.getFacts(),
-            videos: this.getVideos(),
-            qa: this.getQA(),
-            roadsAdded: this.getRoadsAdded(),
-            listsPublished: this.getPublishedLists()
-        }
-    }
+  /**
+   * Gets how many places you added associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of places added.
+   */
+  getPlacesAdded() {
+    let pattern = /(\d+(?:,\d+)*) places* added*/g;
+    const placesAddedString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(placesAddedString);
+  }
 
-    /**
-     * Gets the match result based on the pattern searching through the response body of the web page
-     * @private
-     * @param {RegExp} pattern Pattern used to find matches within the body
-     * @param {string} body Entire web page body
-     * @return {string} first group match result if found, empty string if not found.
-     */
-    getMatch(pattern) {
-        let matches = pattern.exec(this.responseBody);
-        return matches.length > 0 ? matches[1] : "";
-    }
+  /**
+   * Gets how many roads you added associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of roads added.
+   */
+  getRoadsAdded() {
+    let pattern = /(\d+(?:,\d+)*) roads* added/g;
+    const roadsAddedString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(roadsAddedString);
+  }
 
-    /**
-     * Gets the web page response body as a string
-     * @private
-     * @param {string} link Link to your contribution page
-     * @return {string} response data which is a string of the entire web page
-     */
-    async getResponseBody(link) {
-        return (await axios.get(link)).data;
-    }
+  /**
+   * Gets how many Q&As you answered associated with your Local Guide Profile.
+   * @public
+   * @return {number} - The number of Q&As.
+   */
+  getQA() {
+    let pattern = /(\d+(?:,\d+)*) Q\\\\u0026A/g;
+    const qaString = this.getMatch(pattern);
+    return ContributionMetadata.parseNumber(qaString);
+  }
+
+  /**
+   * gets all the metadata in one object
+   * @public
+   * @return {JSON} metadata
+   */
+  async getMetadata() {
+    return {
+      points: this.getPoints(),
+      level: this.getLevel(),
+      reviews: this.getReviews(),
+      ratings: this.getRatings(),
+      photos: this.getPhotos(),
+      videos: this.getVideos(),
+      captions: this.getCaptions(),
+      answers: this.getAnswers(),
+      edits: this.getEdits(),
+      factsChecked: this.getFactsChecked(),
+      placesAdded: this.getPlacesAdded(),
+      roadsAdded: this.getRoadsAdded(),
+      qa: this.getQA(),
+      reportedIncorrect: this.getReportedIncorrect(),
+    };
+  }
+
+  /**
+   * gets the match result based on the pattern searching through the response body of the web page
+   * @private
+   * @param {RegExp} pattern Pattern used to find matches within the body
+   * @param {string} body Entire web page body
+   * @return {string} first group match result if found, empty string if not found.
+   */
+  getMatch(pattern) {
+    let matches = pattern.exec(this.responseBody);
+    console.log(this.responseBody); // referencing variable in the class
+    console.log(matches);
+    return matches.length > 0 ? matches[1] : "";
+  }
+
+  /**
+   * gets the web page response body as a string
+   * @private
+   * @param {string} link Link to your contribution page
+   * @return {string} response data which is a string of the entire web page
+   */
+  async getResponseBody(link) {
+    return (await axios.get(link)).data;
+
+    // Ensure the link is formatted correctly for the proxy
+    // const formattedLink = link.replace('https://www.google.com/maps/contrib/', '/maps/contrib/');
+    // return (await axios.get(`/.netlify/functions/proxy${formattedLink}`)).data;
+  }
+
+  /**
+   * Gets the web page response body as a string
+   * @private
+   * @param {string} link Link to your contribution page
+   * @return {string} response data which is a string of the entire web page
+   */
+  async getResponseBody(link) {
+    return (await axios.get(link)).data;
+  }
 }
 
 module.exports = ContributionMetadata;

--- a/src/ContributionMetadata.js
+++ b/src/ContributionMetadata.js
@@ -1,16 +1,5 @@
 const axios = require("axios");
 
-/**
- * removed the published lists as those no longer count
- * added some new contribution categories
- * renamed "questions" to "answers"
- * parse number helper function added
- * add star after each of s- so regardless if singular (for 1) or plural - it will handle
- * ^we found this out by console.log the responseBody and test it on regex101.com 
- * updated regex to handle commas as noticed first digit cutting off when comma present
- */
-
-// note too: regex is limited to english version of google maps as it uses english words to match
 
 class ContributionMetadata {
   async init(link) {


### PR DESCRIPTION
Hi Jinwook- my friend!
I recently came across your awesome library while designing a Google Map calculator ([repo](https://github.com/ashleyd480/local-guide-points-calculator)) to help volunteers devise contribution plans to reach their goals based on their current contribution data.  Huge fan of your work and thank your for all the hard work you've put into this! <3 

I was able to use your `google-local-guides-api` "library" to initially get my program up and running locally. 

Based on my experience of using it and from being a Local Guide volunteer myself, I noticed and made a few suggested changes that I'm sharing here for your approval/discussion in this Merge Request.  :)

____________________________________________________________________________________________________

**1. Removal of Published Lists:**
The handling of `published lists` has been removed as Google Maps no longer awards points or tracks contributions toward the category of `published lists`.

**2. Addition of New Contribution Categories:**
New contribution categories have been added to better reflect the current added categories that Google Local Guides can contribute to like `captions` This ensures that users can retrieve the most up-to-date information regarding their contributions.

**3. Renaming of "Questions" to "Answers":**
I updated where you termed a category as "questions" to "answers" instead. This is to accurately represent the data being collected, as  This change improves clarity and aligns with how this category is where users answer multiple choice questions provided by Google. 

**4.  Number Parsing Helper Function:**
A new static method, `parseNumber`, has been introduced to facilitate the parsing of numeric values from strings. This method removes commas and converts the cleaned string into an integer, ensuring that numeric data is handled correctly. 
[Without this added, I saw instances where the first digit of a number would be cut off if there were multiple digits and commas present.]

**5. Handling Singular and Plural Forms:**
The regex patterns have been updated to include a star `(*)` after the letter `s` in each of the contribution types (e.g., "photos", "videos"). This adjustment allows the regex to match both singular and plural forms.  [Without this added, if there was only a single contribution in any of those categories, the regex would be unable to retrieve anything since with singular 1 contribution, there is no `s` at the end, i.e "1 photo".]

This changes were validated through console logging of the `responseBody` and testing the regex patterns on regex101.com. This step ensured that the regex patterns are functioning as intended and accurately capturing the required data.

Lastly: 
How about we add a note to the `readme` to clarify that the regex is limited to the English version of Google Maps? The regex code currently relies on English words for matching. This is important for users to understand the context and limitations of the data extraction process. :)

Let me know if any questions or comments. 
